### PR TITLE
Updated make.py to use the wca-document-extra/data branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ before_install:
  - sudo apt-get -y update
  - sudo apt-get install --no-install-recommends -qq -y pandoc fonts-unfonts-core fonts-arphic-uming
  - sudo apt-get install --no-install-recommends -qq -y texlive-lang-all texlive-xetex texlive-latex-recommended texlive-latex-extra lmodern
+ - git fetch origin data:refs/remotes/origin/data
 script: python make.py -w --setup-wca-documents --verbose --num-workers 1


### PR DESCRIPTION
As per discussion on https://github.com/cubing/worldcubeassociation.org/issues/3, I did two things:

1. Created an orphaned "data" branch on cubing/wca-documents-extra: https://github.com/cubing/wca-documents-extra/tree/data.
2. Updated make.py to check out this branch to a temp/ directory and copy its contents into the compiled regulations folder.